### PR TITLE
fix(dockerfile): improve documentation and change working directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,16 @@
 # We use the official Python 3.11 image as our base image and will add our code to it. For more details, see https://hub.docker.com/_/python
 FROM python:3.11-slim
 
-# Speckle Automate will run the container as a non-root user, which we will name 'speckle'.
-# The following creates a group named 'speckle' with an id of 1000, and a user named 'speckle' with an id of 65534. The speckle user is part of the speckle group.
-# The `-m` flag creates a home directory for the user, which is required by the SpecklePy SDK; a config file will be saved here at /home/speckle/.config
-#
-# If running the image locally, e.g. for testing, you should also run it as a non-root user using the `--user speckle:speckle` flag
-# e.g. docker run --rm -it --user speckle:speckle speckle_automate_python_example
-# You can verify the user by running `import getpass; print(getpass.getuser())` in the python shell; it should print 'speckle'
-RUN groupadd --gid 1000 speckle && useradd -m --uid 60000 -g speckle speckle
-
 # We install poetry to generate a list of dependencies which will be required by our application
 RUN pip install poetry
 
-# We set the working directory to be the root directory; all of our files will be copied here.
+# We set the working directory to be the /home/speckle directory; all of our files will be copied here.
 WORKDIR /home/speckle
 
 # Copy all of our code and assets from the local directory into the /home/speckle directory of the container.
 # We also ensure that the user 'speckle' owns these files, so it can access them
 # This assumes that the Dockerfile is in the same directory as the rest of the code
-COPY --chown=speckle:speckle . /home/speckle
+COPY . /home/speckle
 
 # Using poetry, we generate a list of requirements, save them to requirements.txt, and then use pip to install them
 RUN poetry export --format requirements.txt --output /home/speckle/requirements.txt && pip install --requirement /home/speckle/requirements.txt

--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ The code can be tested locally by running `poetry run pytest`.
 
 ### Building and running the Docker Container Image
 
-The code should also be packaged into the format required by Speckle Automate, a Docker Container Image, and that should also be tested.
+Running and testing your code on your own machine is a great way to develop your Function; the following instructions are a bit more in-depth and only required if you are having issues with your Function in GitHub Actions or on Speckle Automate.
+
+#### Building the Docker Container Image
+
+Your code is packaged by the GitHub Action into the format required by Speckle Automate. This is done by building a Docker Image, which is then run by Speckle Automate. You can attempt to build the Docker Image yourself to test the building process locally.
 
 To build the Docker Container Image, you will need to have [Docker](https://docs.docker.com/get-docker/) installed.
 
@@ -67,21 +71,29 @@ Once you have Docker running on your local machine:
     docker build -f ./Dockerfile -t speckle_automate_python_example .
     ```
 
-1. To run the tests, run the following command:
+#### Running the Docker Container Image
 
-    ```bash
-    docker run --rm --user speckle:speckle speckle_automate_python_example poetry run pytest
-    ```
+Once the image has been built by the GitHub Action, it is sent to Speckle Automate. When Speckle Automate runs your Function as part of an Automation, it will run the Docker Container Image. You can test that your Docker Container Image runs correctly by running it locally.
 
 1. To then run the Docker Container Image, run the following command:
 
     ```bash
-    docker run --rm --user speckle:speckle speckle_automate_python_example \
+    docker run --rm speckle_automate_python_example \
     python -u main.py run \
     '{"projectId": "1234", "modelId": "1234", "branchName": "myBranch", "versionId": "1234", "speckleServerUrl": "https://speckle.xyz", "automationId": "1234", "automationRevisionId": "1234", "automationRunId": "1234", "functionId": "1234", "functionName": "my function", "functionLogo": "base64EncodedPng"}' \
     '{}' \
     yourSpeckleServerAuthenticationToken
     ```
+
+Let's explain this in more detail:
+
+`docker run --rm speckle_automate_python_example` tells Docker to run the Docker Container Image that we built earlier. `speckle_automate_python_example` is the name of the Docker Container Image that we built earlier. The `--rm` flag tells docker to remove the container after it has finished running, this frees up space on your machine.
+
+The line `python -u main.py run` is the command that is run inside the Docker Container Image. The rest of the command is the arguments that are passed to the command. The arguments are:
+
+- `'{"projectId": "1234", "modelId": "1234", "branchName": "myBranch", "versionId": "1234", "speckleServerUrl": "https://speckle.xyz", "automationId": "1234", "automationRevisionId": "1234", "automationRunId": "1234", "functionId": "1234", "functionName": "my function", "functionLogo": "base64EncodedPng"}'` - the metadata that describes the automation and the function.
+- `{}` - the input parameters for the function that the Automation creator is able to set. Here they are blank, but you can add your own parameters to test your function.
+- `yourSpeckleServerAuthenticationToken` - the authentication token for the Speckle Server that the Automation can connect to. This is required to be able to interact with the Speckle Server, for example to get data from the Model.
 
 ## Resources
 


### PR DESCRIPTION
- Adds inline commentary to the Dockerfile to help new users understand it.
- Installs code at `/home/speckle` to prevent collisions with files & directories in the root (`/`) directory, and changes the working directory to `/home/speckle` so the command remains the same.
- Updates the README and provides instructions for building and testing the docker image locally
