### PR TITLE
chore(deps): pin poetry better

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,13 +15,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install and configure Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: 1.8.3
-          virtualenvs-create: false
-          virtualenvs-in-project: false
-          installer-parallel: true
+      - name: Install poetry
+        run: |
+          pip install poetry==1.8.4 &&
+          poetry config virtualenvs.create false &&
+          poetry config virtualenvs.in-project false &&
+          poetry config installer.parallel true
       - name: Restore dependencies
         run: poetry install --no-root
       - name: Extract functionInputSchema

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.11-slim
 
 # We install poetry to generate a list of dependencies which will be required by our application
-RUN pip install poetry
+RUN pip install poetry==1.8.4
 
 # We set the working directory to be the /home/speckle directory; all of our files will be copied here.
 WORKDIR /home/speckle


### PR DESCRIPTION
new function build and publish was failing because poetry released a 2.0.0 version (with breaking changes) and we were not pinning aggressively enough

- pins to latest working version (1.8.4)
- drops "install poetry" action for explicit commands (it was misbehaving wrt plugins)

It also seems like we can remove the redundant build in the github action? Is this maybe meant as a "preflight check" before running the composite action?